### PR TITLE
Change PostCSS to v8

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 const easingCoordinates = require('easing-coordinates')
-const postcss = require('postcss')
 const valueParser = require('postcss-value-parser')
 const getColorStops = require('./lib/colorStops.js')
 const helpers = require('./lib/helpers.js')
@@ -7,59 +6,57 @@ const helpers = require('./lib/helpers.js')
 /**
  * The easing gradient function is a postcss plugin which supports the in /.helpers mentioned gradient types.
  */
-module.exports = postcss.plugin('easing-gradient', (options = {}) => {
+module.exports = (options = {}) => {
   if (!options.stops) {
     options.stops = 13
   }
-  return function(css) {
-    css.walkRules(rule => {
-      rule.walkDecls(decl => {
-        // If declaration value contains a -gradient.
-        if (decl.value.includes('-gradient')) {
-          // Parse the declaration and walk through the nodes - https://github.com/TrySound/postcss-value-parser.
-          const parsedValue = valueParser(decl.value)
-          parsedValue.walk(node => {
-            // Only modify gradient as the value can contain more e.g. 'linear-gradient(black, pink) center'.
-            if (node.value === 'linear-gradient' || node.value === 'radial-gradient') {
-              // Get a sensible array of gradient parameters where e.g. a function is split into multiple array items
-              const gradientParams = valueParser
-                .stringify(helpers.divToSemiColon(node.nodes))
-                .split(';')
-                .map(str => str.trim())
+  return {
+    postcssPlugin: 'easing-gradient',
+    Declaration(decl) {
+      // If declaration value contains a -gradient.
+      if (decl.value.includes('-gradient')) {
+        // Parse the declaration and walk through the nodes - https://github.com/TrySound/postcss-value-parser.
+        const parsedValue = valueParser(decl.value)
+        parsedValue.walk(node => {
+          // Only modify gradient as the value can contain more e.g. 'linear-gradient(black, pink) center'.
+          if (node.value === 'linear-gradient' || node.value === 'radial-gradient') {
+            // Get a sensible array of gradient parameters where e.g. a function is split into multiple array items
+            const gradientParams = valueParser
+              .stringify(helpers.divToSemiColon(node.nodes))
+              .split(';')
+              .map(str => str.trim())
 
-              gradientParams.forEach((param, i) => {
-                if (helpers.isTimingFunction(param)) {
-                  try {
-                    const colors = [gradientParams[i - 1], gradientParams[i + 1]]
-                    const coordinates = easingCoordinates.easingCoordinates(
-                      param,
-                      options.stops - 1
-                    )
-                    const colorStops = getColorStops(
-                      colors,
-                      coordinates,
-                      options.alphaDecimals,
-                      options.colorMode
-                    )
-                    // Update node
-                    node.type = 'word'
-                    // Assume if it has 4 params it's because the first one is the direction
-                    if (gradientParams.length === 4) {
-                      node.value = `${node.value}(${gradientParams[0]}, ${colorStops.join(', ')})`
-                    } else {
-                      node.value = `${node.value}(${colorStops.join(', ')})`
-                    }
-                    // Update our declaration value
-                    decl.value = parsedValue.toString()
-                  } catch (error) {
-                    console.log(helpers.errorMsg(decl.value))
+            gradientParams.forEach((param, i) => {
+              if (helpers.isTimingFunction(param)) {
+                try {
+                  const colors = [gradientParams[i - 1], gradientParams[i + 1]]
+                  const coordinates = easingCoordinates.easingCoordinates(param, options.stops - 1)
+                  const colorStops = getColorStops(
+                    colors,
+                    coordinates,
+                    options.alphaDecimals,
+                    options.colorMode
+                  )
+                  // Update node
+                  node.type = 'word'
+                  // Assume if it has 4 params it's because the first one is the direction
+                  if (gradientParams.length === 4) {
+                    node.value = `${node.value}(${gradientParams[0]}, ${colorStops.join(', ')})`
+                  } else {
+                    node.value = `${node.value}(${colorStops.join(', ')})`
                   }
+                  // Update our declaration value
+                  decl.value = parsedValue.toString()
+                } catch (error) {
+                  console.log(helpers.errorMsg(decl.value))
                 }
-              })
-            }
-          })
-        }
-      })
-    })
+              }
+            })
+          }
+        })
+      }
+    },
   }
-})
+}
+
+module.exports.postcss = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,6 +179,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -207,6 +208,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -1167,6 +1169,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1287,6 +1290,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "dev": true,
       "requires": {
         "color-name": "^1.1.1"
       }
@@ -1294,7 +1298,14 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colorette": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -1650,7 +1661,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.11.0",
@@ -2344,7 +2356,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2365,12 +2378,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2385,17 +2400,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2512,7 +2530,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2524,6 +2543,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2538,6 +2558,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2545,12 +2566,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2569,6 +2592,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2649,7 +2673,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2661,6 +2686,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2746,7 +2772,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2782,6 +2809,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2801,6 +2829,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2844,12 +2873,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3029,7 +3060,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -4210,6 +4242,16 @@
         "type-check": "~0.3.2"
       }
     },
+    "line-column": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/line-column/-/line-column-1.0.2.tgz",
+      "integrity": "sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=",
+      "dev": true,
+      "requires": {
+        "isarray": "^1.0.0",
+        "isobject": "^2.0.0"
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -4320,7 +4362,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -4500,6 +4543,12 @@
       "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
       "dev": true,
       "optional": true
+    },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
+      "dev": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -4939,13 +4988,15 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
-      "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.1.2.tgz",
+      "integrity": "sha512-mToqEVFq8jF9TFhlIK4HhE34zknFJuNTgqtsr60vUvrWn+9TIYugCwiV1JZRxCuOrej2jjstun1bn4Bc7/1HkA==",
+      "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
-        "source-map": "^0.6.1",
-        "supports-color": "^5.4.0"
+        "colorette": "^1.2.1",
+        "line-column": "^1.0.2",
+        "nanoid": "^3.1.12",
+        "source-map": "^0.6.1"
       }
     },
     "postcss-value-parser": {
@@ -6089,7 +6140,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -6292,6 +6344,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "postcss-easing-gradients",
   "version": "3.0.1",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=10.0.0"
   },
   "description": "PostCSS plugin to create smooth linear-gradients that approximate easing functions.",
   "scripts": {
@@ -28,7 +28,6 @@
   "dependencies": {
     "chroma-js": "^1.3.7",
     "easing-coordinates": "^2.0.0",
-    "postcss": "^7.0.2",
     "postcss-value-parser": "^3.3.0"
   },
   "devDependencies": {
@@ -45,8 +44,12 @@
     "eslint-plugin-security": "^1.4.0",
     "eslint-plugin-standard": "^4.0.0",
     "jest": "^23.5.0",
+    "postcss": "^8.1.2",
     "prettier": "^1.14.2",
     "prettier-eslint": "^8.8.2"
+  },
+  "peerDependencies": {
+    "postcss": "^8.1.2"
   },
   "eslintConfig": {
     "plugins": [


### PR DESCRIPTION
* Changed `postcss` dependency version to 8 :new:, [plugin migration guide](https://evilmartians.com/chronicles/postcss-8-plugin-migration).
* Changed Node.js version to 10. Note: PostCSS v8 dropped Node.js 6.x, 8.x, 11.x, and 13.x versions support.

Closes #12