### PR TITLE
Added Chroma.js workaround for it not yet supporting 'deg' units:

### DIFF
--- a/lib/colorStops.js
+++ b/lib/colorStops.js
@@ -15,7 +15,12 @@ module.exports = (colors, coordinates, alphaDecimals = 5, colorMode = 'lrgb') =>
   coordinates.forEach(coordinate => {
     const ammount = coordinate.y
     const percent = coordinate.x * 100
-    let color = chroma.mix(colors[0], colors[1], ammount, colorMode).css('hsl')
+    let color = chroma.mix(
+      helpers.chromaDegreesWorkaround(colors[0]),
+      helpers.chromaDegreesWorkaround(colors[1]),
+      ammount,
+      colorMode
+    ).css('hsl')
     color = helpers.roundHslAlpha(color, alphaDecimals)
     if (Number(coordinate.x) !== 0 && Number(coordinate.x) !== 1) {
       colorStops.push(`${color} ${+percent.toFixed(2)}%`)

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -85,6 +85,28 @@ exports.roundHslAlpha = (color, alphaDecimals) => {
 }
 
 /**
+ * Chroma.js 'deg' unit workaround.
+ *
+ * Chroma.js doesn't yet support hsl()/hsla() colors that have the 'deg' unit,
+ * so this strips the unit out to prevent Chroma.js throwing an error. If no
+ * unit is specified for the hue value, the CSS spec says that it must be
+ * interpreted as degrees for backward compatibility.
+ *
+ * @param {String} color A CSS color value.
+ *
+ * @return {String} The color parameter with any 'deg' unit stripped from the
+ * hue.
+ *
+ * @see https://github.com/gka/chroma.js/issues/297
+ *   Open Chroma.js issue regarding the newer color formats.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl
+ */
+exports.chromaDegreesWorkaround = (color) => {
+  return color.replaceAll(/(hsla?\(\s*\d+)deg([,\s].+)$/gm, '$1$2');
+}
+
+/**
  * Wrap a string telling the user we couldn't parse it
  * @param {String} input A string
  * @returns {String} The full error message wrapped around the string


### PR DESCRIPTION
This works around gka/chroma.js#297 by stripping the 'deg' unit in `hsl()`/`hsla()` colours, which fixes instances of this plug-in failing to parse the newer colour format. This is particularly a problem with Sass, as it tends to output to the newer format. Without this workaround, you'd get errors such as these:

```
Couldn't parse:
linear-gradient(to bottom, hsl(0deg, 0%, 95%), cubic-bezier(0.4, 0, 1, 1), rgba(242, 242, 242, 0))
Check the syntax to see if it's correct/supported.
Couldn't parse:
linear-gradient(to bottom, hsl(0deg, 0%, 4%), cubic-bezier(0.4, 0, 1, 1), rgba(10, 10, 10, 0))
Check the syntax to see if it's correct/supported.
Couldn't parse:
linear-gradient(to top, hsl(0deg, 0%, 95%), cubic-bezier(0.4, 0, 1, 1), rgba(242, 242, 242, 0))
Check the syntax to see if it's correct/supported.
Couldn't parse:
linear-gradient(to top, hsl(0deg, 0%, 4%), cubic-bezier(0.4, 0, 1, 1), rgba(10, 10, 10, 0))
Check the syntax to see if it's correct/supported.
```